### PR TITLE
update dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,13 +12,13 @@ dependencies:
   flutter:
     sdk: flutter
   universal_io: ^2.0.4
-  device_info_plus: ^4.1.2
+  device_info_plus: ^8.0.0
 
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
 
 # The following section is specific to Flutter.
 flutter:


### PR DESCRIPTION
Because this package is dependent on device_info_plus 4.1.2, we are unable to update the device_info_plus package in defio. Change log is already checked and there are no breaking changes.